### PR TITLE
Disable SMPlayer rule for now

### DIFF
--- a/jiup/rules/reachability-test/main.go
+++ b/jiup/rules/reachability-test/main.go
@@ -17,7 +17,6 @@ import (
 var KnownBroken = []string{
 	"audacity",         // https://github.com/just-install/just-install-updater-go/issues/17
 	"crystaldisk-info", // TODO: fixme
-	"smplayer",         // SMPlayer 19.10.2 is a source-only download
 }
 
 func main() {

--- a/jiup/rules/rules.go
+++ b/jiup/rules/rules.go
@@ -1280,16 +1280,19 @@ func init() {
 			nil,
 		),
 	)
-	Rule("smplayer",
-		v.Regexp(
-			"https://sourceforge.net/projects/smplayer/files/",
-			h.Re("smplayer-([0-9.]+)\\."),
-		),
-		d.Template(
-			"https://sourceforge.net/projects/smplayer/files/SMPlayer/{{.Version}}/smplayer-{{.Version}}-win32.exe/download",
-			"https://sourceforge.net/projects/smplayer/files/SMPlayer/{{.Version}}/smplayer-{{.Version}}-x64.exe/download",
-		),
-	)
+	// FIXME: SMPlayer's download page says "Download Latest Version smplayer-19.10.2.tar.bz2 (5.2
+	// MB)" but that version doesn't have an installer (it's a source-only download).
+	//
+	// Rule("smplayer",
+	//  v.Regexp(
+	//      "https://sourceforge.net/projects/smplayer/files/",
+	//      h.Re("smplayer-([0-9.]+)\\."),
+	//  ),
+	//  d.Template(
+	//      "https://sourceforge.net/projects/smplayer/files/SMPlayer/{{.Version}}/smplayer-{{.Version}}-win32.exe/download",
+	//      "https://sourceforge.net/projects/smplayer/files/SMPlayer/{{.Version}}/smplayer-{{.Version}}-x64.exe/download",
+	//  ),
+	// )
 	Rule("sourcetree",
 		v.Regexp(
 			"https://www.sourcetreeapp.com",


### PR DESCRIPTION
SMPlayer 19.10.2 appears to be a source-only version and we should pick an earlier version (19.0.0?) that still provides binaries.

I previously added SMPlayer to the "KnownBroken" list but technically the rule isn't failing, so it has no effect. Instead, I commented it out, but I'm not entirely sure this is the right approach 😅 Can you give it a look?