### PR TITLE
Removed gog-galaxy rule

### DIFF
--- a/jiup/rules/rules.go
+++ b/jiup/rules/rules.go
@@ -650,17 +650,6 @@ func init() {
 			"https://dl.google.com/go/go{{.Version}}.windows-amd64.msi",
 		),
 	)
-	Rule("gog-galaxy",
-		v.Regexp(
-			"https://www.gog.com/galaxy",
-			h.Re("setup_galaxy_([0-9.]+).exe"),
-		),
-		d.HTMLA(
-			"https://www.gog.com/galaxy",
-			"a[href*='setup'][href$='.exe']:contains('Windows')",
-			"",
-		),
-	)
 	Rule("gow",
 		v.GitHubRelease(
 			"bmatzelle/gow",


### PR DESCRIPTION
They have a payload parameter in the URL. Probably we can't do anything about it. This is the URL on their website: `https://webinstallers.gog.com/download/GOG_Galaxy_2.0.exe?payload=G4xkqJnN6xaZZL_KGNpboAd32GLp3TOtZNNAAiplaqE1aIa4VVbztlwnFECEjBROI0Hwk0oeryvMc1wr0hZNR3d18GmWTCgyce1VOCGiwCyiuIzVSw..`