### PR TITLE
Removed mpc-hc rule

### DIFF
--- a/jiup/rules/rules.go
+++ b/jiup/rules/rules.go
@@ -893,17 +893,6 @@ func init() {
 			"",
 		),
 	)
-	Rule("mpc-hc",
-		v.Regexp(
-			"https://mpc-hc.org/downloads/",
-			h.Re("latest stable build is v([0-9.]+)"),
-		),
-		d.HTMLA(
-			"https://mpc-hc.org/downloads/",
-			"a[href$='.x86.exe']",
-			"a[href$='.x64.exe']",
-		),
-	)
 	Rule("mumble",
 		v.GitHubRelease(
 			"mumble-voip/mumble",


### PR DESCRIPTION
v1.7.13 was last release as stated in https://mpc-hc.org/2017/07/16/1.7.13-released-and-farewell/
There were no news from the project after that.

@geek1011 Do you think that it should also be removed from the registry?