### PR TITLE
Removed crystaldisk-info from KnownBroken

### DIFF
--- a/jiup/rules/reachability-test/main.go
+++ b/jiup/rules/reachability-test/main.go
@@ -16,7 +16,6 @@ import (
 // Errors during the check will not count as a failure.
 var KnownBroken = []string{
 	"audacity",         // https://github.com/just-install/just-install-updater-go/issues/17
-	"crystaldisk-info", // TODO: fixme
 }
 
 func main() {


### PR DESCRIPTION
The test for `crystaldisk-info` works fine and the reason for adding it was not documented.