### PR TITLE
Changed audacity rule to download from fossies

### DIFF
--- a/jiup/rules/reachability-test/main.go
+++ b/jiup/rules/reachability-test/main.go
@@ -15,7 +15,6 @@ import (
 // KnownBroken contains packages known to be broken.
 // Errors during the check will not count as a failure.
 var KnownBroken = []string{
-	"audacity",         // https://github.com/just-install/just-install-updater-go/issues/17
 }
 
 func main() {

--- a/jiup/rules/rules.go
+++ b/jiup/rules/rules.go
@@ -58,13 +58,10 @@ func init() {
 			"http://www.oldfoss.com/Audacity.html",
 			h.Re("audacity-win-([0-9.]+).exe"),
 		),
-		func(version string) (*string, *string, error) {
-			return d.Regexp(
-				"http://www.oldfoss.com/Audacity.html",
-				h.Re("\"(http.+audacity-win-"+version+".exe)\""),
-				nil,
-			)(version)
-		},
+		d.Template(
+			"https://fossies.org/windows/misc/audacity-win-{{.Version}}.exe",
+			"",
+		),
 	)
 	Rule("bleachbit",
 		v.Regexp(


### PR DESCRIPTION
It's not in the repo anymore. `winget` is downloading from fossies.org (https://github.com/microsoft/winget-pkgs/pull/923/files). We could also use that. If you think it's worth having audacity in j-i, I can add an entry with it to the registry and an updater rule.