### PR TITLE
Removed defraggler and recuva rules

### DIFF
--- a/jiup/rules/rules.go
+++ b/jiup/rules/rules.go
@@ -288,23 +288,6 @@ func init() {
 			h.Re("dbeaver-ce-.+-x86_64-setup.exe"),
 		),
 	)
-	Rule("defraggler",
-		func() (string, error) {
-			version, err := v.Regexp(
-				"https://www.ccleaner.com/defraggler/download/standard",
-				h.Re("dfsetup([0-9]+)"),
-			)()
-			if err != nil {
-				return "", err
-			}
-			return string(version[0]) + "." + string(version[1:]), nil
-		},
-		d.HTMLA(
-			"https://www.ccleaner.com/defraggler/download/standard",
-			"a[href$='.exe']:contains('start the download')",
-			"",
-		),
-	)
 	Rule("deluge",
 		v.Regexp(
 			"https://ftp.osuosl.org/pub/deluge/windows/?C=M;O=D",
@@ -1270,23 +1253,6 @@ func init() {
 			"qTox/qTox",
 			h.Re("setup-qtox-i686-release.exe"),
 			h.Re("setup-qtox-x86_64-release.exe"),
-		),
-	)
-	Rule("recuva",
-		func() (string, error) {
-			version, err := v.Regexp(
-				"https://www.ccleaner.com/recuva/download/standard",
-				h.Re("rcsetup([0-9]+)"),
-			)()
-			if err != nil {
-				return "", err
-			}
-			return string(version[0]) + "." + string(version[1:]), nil
-		},
-		d.HTMLA(
-			"https://www.ccleaner.com/recuva/download/standard",
-			"a[href$='.exe']:contains('start the download')",
-			"",
 		),
 	)
 	Rule("retroarch",


### PR DESCRIPTION
They were removed from the registry in https://github.com/just-install/registry/commit/2ce85b38b6c4a825a0449ce83ce846c026cfa809 and are causing updater failures.