### PR TITLE
Changed moonlight-qt rule

### DIFF
--- a/jiup/rules/rules.go
+++ b/jiup/rules/rules.go
@@ -950,8 +950,8 @@ func init() {
 			h.Re("v(.+)"),
 		),
 		d.Template(
-			"https://github.com/moonlight-stream/moonlight-qt/releases/download/v{{.Version}}/MoonlightSetup-x86-{{.Version}}.exe",
-			"https://github.com/moonlight-stream/moonlight-qt/releases/download/v{{.Version}}/MoonlightSetup-x64-{{.Version}}.exe",
+			"https://github.com/moonlight-stream/moonlight-qt/releases/download/v{{.Version}}/MoonlightSetup-{{.Version}}.exe",
+			"https://github.com/moonlight-stream/moonlight-qt/releases/download/v{{.Version}}/MoonlightSetup-{{.Version}}.exe",
 		),
 	)
 	Rule("mountainduck",


### PR DESCRIPTION
The same download URL is twice because the same installer is for both x86 and x64.